### PR TITLE
feat: 将钉钉消息类型从link 修改为actionCard

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,5 @@ xbmlz/sonar-dingtalk-plugin
 
 完成上述步骤，就可以将sonarqube扫描结果，推送到钉钉群了
 
-![](https://cdn.jsdelivr.net/gh/xbmlz/static@main/img/202206181406084.png)
+<img width="451" alt="iShot" src="https://github.com/viewhang/sonar-dingtalk-plugin/assets/26957298/a41f7be5-509c-4015-bf88-ef8e681df40b">
+


### PR DESCRIPTION
因钉钉改版，link 类型消息显示不全，不美观
<img width="483" alt="image" src="https://github.com/xbmlz/sonar-dingtalk-plugin/assets/26957298/92eb6168-4185-4d5a-8ee9-cd2b5166eb44">
所以修改为actionCard，更加美观实用
<img width="451" alt="iShot_2024-05-23_15 27 43" src="https://github.com/xbmlz/sonar-dingtalk-plugin/assets/26957298/8683b755-4775-46b3-a19e-b8a91bdd2097">

